### PR TITLE
Paragraphs and inline image

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,11 @@ var insertCaptions = function(section) {
   var $ = cheerio.load(section.content);
   $('img').each(function(i, elem) {
     var img = $(elem);
+    if (img.parent().children().length > 1 || img.parent().text() != '') return;
     var wrapImage = function(caption) {
       var template = options.caption || 'Figure: _CAPTION_';
       var result = template.replace('_CAPTION_', caption);
-      img.replaceWith('<figure>' + $.html(img) + '<figcaption>'+result+'</figcaption></figure>');
+      img.parent().replaceWith('<figure>' + $.html(img) + '<figcaption>'+result+'</figcaption></figure>');
     };
     var title = img.attr('title');
     var alt = img.attr('alt');
@@ -40,7 +41,7 @@ module.exports = {
         assets: './assets',
         css: [
             'image-captions.css'
-        ],
+        ]
     },
     ebook: {
       assets: './assets',

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ var insertCaptions = function(section) {
   var $ = cheerio.load(section.content);
   $('img').each(function(i, elem) {
     var img = $(elem);
-    if (img.parent().children().length > 1 || img.parent().text() != '') return;
+    if (img.parent().children().length > 1 || img.parent().text() !== '') {
+        return;
+    }
     var wrapImage = function(caption) {
       var template = options.caption || 'Figure: _CAPTION_';
       var result = template.replace('_CAPTION_', caption);

--- a/spec/tests_spec.js
+++ b/spec/tests_spec.js
@@ -86,4 +86,32 @@ describe(__filename, function () {
     expect(page.sections[0].content).toEqual('<figure><img src="foo.jpg" alt="bar" title=""><figcaption>Figure: bar</figcaption></figure>');
     done();
   });
+
+  it('should ignore inline images (pre)', function (done) {
+    var page = {'sections':[{'type':'normal', 'content': '<p>foo <img src="foo.jpg" alt="bar"></p>'}]};
+    onPageHook.call(plugin, page); // call the hook, preserving plugin scope
+    expect(page.sections[0].content).toEqual('<p>foo <img src="foo.jpg" alt="bar"></p>');
+    done();
+  });
+
+  it('should ignore inline images (post)', function (done) {
+    var page = {'sections':[{'type':'normal', 'content': '<p><img src="foo.jpg" alt="bar"> bar</p>'}]};
+    onPageHook.call(plugin, page); // call the hook, preserving plugin scope
+    expect(page.sections[0].content).toEqual('<p><img src="foo.jpg" alt="bar"> bar</p>');
+    done();
+  });
+
+  it('should ignore inline images', function (done) {
+    var page = {'sections':[{'type':'normal', 'content': '<p>foo <img src="foo.jpg" alt="bar"> bar</p>'}]};
+    onPageHook.call(plugin, page); // call the hook, preserving plugin scope
+    expect(page.sections[0].content).toEqual('<p>foo <img src="foo.jpg" alt="bar"> bar</p>');
+    done();
+  });
+
+  it('should ignore multiple images in paragraph', function (done) {
+    var page = {'sections':[{'type':'normal', 'content': '<p><img src="foo1.jpg" alt="bar1"><img src="foo2.jpg" alt="bar2"></p>'}]};
+    onPageHook.call(plugin, page); // call the hook, preserving plugin scope
+    expect(page.sections[0].content).toEqual('<p><img src="foo1.jpg" alt="bar1"><img src="foo2.jpg" alt="bar2"></p>');
+    done();
+  });
 });

--- a/spec/tests_spec.js
+++ b/spec/tests_spec.js
@@ -11,9 +11,9 @@ describe(__filename, function () {
   var onPageHook = plugin.hooks.page;  // reference to the hook method
 
   it('should ignore all sections except \'normal\'', function (done) {
-    var page = {'sections':[{'type':'exercise', 'content': '<img src="foo.jpg" alt="bar">'},{'type':'unknown', 'content': 'aaa'}]};
+    var page = {'sections':[{'type':'exercise', 'content': '<p><img src="foo.jpg" alt="bar"></p>'},{'type':'unknown', 'content': 'aaa'}]};
     onPageHook.call(plugin, page); // call the hook, preserving plugin scope
-    expect(page.sections[0].content).toEqual('<img src="foo.jpg" alt="bar">');
+    expect(page.sections[0].content).toEqual('<p><img src="foo.jpg" alt="bar"></p>');
     done();
   });
 
@@ -25,7 +25,7 @@ describe(__filename, function () {
   });
 
   it('should create caption from alt attribute', function (done) {
-    var page = {'sections':[{'type':'normal', 'content': '<img src="foo.jpg" alt="bar">'}]};
+    var page = {'sections':[{'type':'normal', 'content': '<p><img src="foo.jpg" alt="bar"></p>'}]};
     onPageHook.call(plugin, page); // call the hook, preserving plugin scope
     expect(page.sections[0].content).toEqual('<figure><img src="foo.jpg" alt="bar"><figcaption>Figure: bar</figcaption></figure>');
     done();
@@ -39,7 +39,7 @@ describe(__filename, function () {
          }
        }
      };
-     var page = {'sections':[{'type':'normal', 'content': '<img src="foo.jpg" alt="bar">'}]};
+     var page = {'sections':[{'type':'normal', 'content': '<p><img src="foo.jpg" alt="bar"></p>'}]};
      onPageHook.call(plugin, page); // call the hook, preserving plugin scope
      expect(page.sections[0].content).toEqual('<figure><img src="foo.jpg" alt="bar"><figcaption>Image - bar</figcaption></figure>');
      done();
@@ -53,35 +53,35 @@ describe(__filename, function () {
          }
        }
      };
-     var page = {'sections':[{'type':'normal', 'content': '<img src="foo.jpg" alt="bar">'}]};
+     var page = {'sections':[{'type':'normal', 'content': '<p><img src="foo.jpg" alt="bar"></p>'}]};
      onPageHook.call(plugin, page); // call the hook, preserving plugin scope
      expect(page.sections[0].content).toEqual('<figure><img src="foo.jpg" alt="bar"><figcaption class="left">Figure: bar</figcaption></figure>');
      done();
     });
 
   it('should prefer title attribute if available', function (done) {
-    var page = {'sections':[{'type':'normal', 'content': '<img src="foo.jpg" alt="bar" title="loremipsum">'}]};
+    var page = {'sections':[{'type':'normal', 'content': '<p><img src="foo.jpg" alt="bar" title="loremipsum"></p>'}]};
     onPageHook.call(plugin, page); // call the hook, preserving plugin scope
     expect(page.sections[0].content).toEqual('<figure><img src="foo.jpg" alt="bar" title="loremipsum"><figcaption>Figure: loremipsum</figcaption></figure>');
     done();
   });
 
   it('should should ignore image without alt and title', function (done) {
-    var page = {'sections':[{'type':'normal', 'content': '<img src="foo.jpg">'}]};
+    var page = {'sections':[{'type':'normal', 'content': '<p><img src="foo.jpg"></p>'}]};
     onPageHook.call(plugin, page); // call the hook, preserving plugin scope
-    expect(page.sections[0].content).toEqual('<img src="foo.jpg">');
+    expect(page.sections[0].content).toEqual('<p><img src="foo.jpg"></p>');
     done();
   });
 
   it('should ignore images with empty alt', function (done) {
-    var page = {'sections':[{'type':'normal', 'content': '<img src="foo.jpg" alt="">'}]};
+    var page = {'sections':[{'type':'normal', 'content': '<p><img src="foo.jpg" alt=""></p>'}]};
     onPageHook.call(plugin, page); // call the hook, preserving plugin scope
-    expect(page.sections[0].content).toEqual('<img src="foo.jpg" alt="">');
+    expect(page.sections[0].content).toEqual('<p><img src="foo.jpg" alt=""></p>');
     done();
   });
 
   it('should ignore images with empty title and fallback to alt', function (done) {
-    var page = {'sections':[{'type':'normal', 'content': '<img src="foo.jpg" alt="bar" title="">'}]};
+    var page = {'sections':[{'type':'normal', 'content': '<p><img src="foo.jpg" alt="bar" title=""></p>'}]};
     onPageHook.call(plugin, page); // call the hook, preserving plugin scope
     expect(page.sections[0].content).toEqual('<figure><img src="foo.jpg" alt="bar" title=""><figcaption>Figure: bar</figcaption></figure>');
     done();


### PR DESCRIPTION
I've installed this plugin and like it a lot. However, I found out that the Markdown parser is always adding a paragraph for each line.
### Problem 1

```
Lorem Ipsum dolor …

![foobar](foo/bar.jpeg)

… sit amet
```

will result in this HTML:

``` html
<p>Lorem Ipsum dolor …</p>

<p><img src="foo/bar.jpeg" alt="foobar"></p>

<p>… sit amet</p>
```

This plugin then converts it to a figure with caption. However, a figure (block element) is not allowed within a paragraph (invalid HTML). 
### Problem 2

Additionally, it will break the content if the image is inline.

```
Lorem Ipsum dolor ![foobar](foo/bar.jpeg) … sit amet
```

will result in 

``` html
<p>Lorem Ipsum dolor <img src="foo/bar.jpeg" alt="foobar"> sit amet</p>
```

Converting the inline image in this case is wrong, because it would become a block element due to `<figure>` (apart from problem 1).
### Solution

I have changed the plugin to only handle image tags that are inside empty paragraphs, and then also remove the paragraph. I hope my assumption about the markdown parser is correct, but as the plugin is for Gitbook I guess we can assume always the same parser…
