### PR TITLE
don't process the same page multiple times

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,12 +193,17 @@ var parseImageData = function (page, index, img) {
 
 var readAllImages = function (gitbook) {
   var promises = [];
+  var pagesToScan = [];
 
   var pageIndex = 0;
 
   gitbook.summary.walk(function (page) {
     var currentPageIndex = pageIndex++;
     if (page.path) { // Check that there is truly a link
+      if (pagesToScan.indexOf(page.path) !== -1)
+          return;
+      pagesToScan.push(page.path);
+      console.log(page.path);
       promises.push(
         getPageHtmlContent(gitbook, page)
         .then(function (pageContent) {

--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,6 @@ var readAllImages = function (gitbook) {
       if (pagesToScan.indexOf(page.path) !== -1)
           return;
       pagesToScan.push(page.path);
-      console.log(page.path);
       promises.push(
         getPageHtmlContent(gitbook, page)
         .then(function (pageContent) {


### PR DESCRIPTION
Noticed with a summary that has multiple links to the same markdown file, the image count would be way off for images in other files (later in the summary).